### PR TITLE
Remove the unnecessary "tabs" permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Tab Limiter",
 	"description": "Limit the number of open tabs in total and in a single window",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"author": "Matthias Vogt",
   	"homepage_url": "https://github.com/matthias-vogt/tab-limiter",
 
@@ -25,7 +25,6 @@
 		]
 	},
 	"permissions": [
-		"tabs",
 		"storage"
 	],
 


### PR DESCRIPTION
Currently, when installing the extension from the Chrome web store, the user is notified that the extension can `Read your browsing history`.

![image](https://user-images.githubusercontent.com/624286/92419327-eaecb500-f13a-11ea-919d-4cb07c2379c5.png)

[According to the docs](https://developer.chrome.com/extensions/permission_warnings#permissions_with_warnings), this is because the `tabs` permission is requested. However, the `tabs` permission is [only required](https://developer.chrome.com/extensions/tabs#type-Tab) if any of the following attributes of the `tab` object are needed:

- `url`
- `pendingUrl`
- `title`
- `favIconUrl`

[Per the docs](https://developer.chrome.com/extensions/declare_permissions), the `tabs` permission (emphasis mine):

> Gives your extension access to privileged fields of the [Tab](https://developer.chrome.com/extensions/tabs#type-Tab) objects used by several APIs including [chrome.tabs](https://developer.chrome.com/extensions/tabs) and [chrome.windows](https://developer.chrome.com/extensions/windows). **In many circumstances your extension will not need to declare the "tabs" permission to make use of these APIs.**

This extension does not use any of these properties, so it can use the `chrome.tabs` API without requesting the `tabs` permission. Removing this permission request will give users more confidence that the extension is secure and safe to use, since they will no longer be notified that it can read their browsing history.